### PR TITLE
Feat: add ALT+CLICK, CTRL+BACKSPACE and COMMAND+BACKSPACE to the shortcuts list

### DIFF
--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -29,4 +29,4 @@ sidebar_position: 7
 | SHIFT+Wheel up / SHIFT+Wheel down | Scroll horizontally |  |
 | CTRL+H | Open shortcuts |  |
 | CTRL+BACKSPACE / COMMAND+BACKSPACE | Delete word before cursor |  |
-| ALT+CLICK | Select multiple elements |  |
+| ALT+CLICK | Select multiple elements | If you want to select multiple elements, hold down the ALT key while clicking on them. |


### PR DESCRIPTION
in this pull request the shortcuts for area selection and line deletion has added to the shortcuts list.

<img width="1158" height="530" alt="image" src="https://github.com/user-attachments/assets/4f463db4-b47b-425b-8f0f-b73b80c0ede9" />
