### PR TITLE
Fix incorrect Ctrl+H shortcut description

### DIFF
--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -27,4 +27,4 @@ sidebar_position: 7
 | CTRL+DOWN / CTRL+Wheel down | Zoom out |  |
 | Wheel up / Wheel down | Scroll vertically |  |
 | SHIFT+Wheel up / SHIFT+Wheel down | Scroll horizontally |  |
-| CTRL+H | Open shortcuts |  |
+| CTRL+H | Open docs |  |


### PR DESCRIPTION
This PR fixes a documentation issue where Ctrl+H was described as opening
the Keyboard Shortcuts panel.

Ctrl+H is intended to open the Docs page.
The shortcut description has now been updated accordingly.